### PR TITLE
docs: recommend --app flag with behavior for always-available MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,28 @@ This module enables Amplifier to connect to MCP servers and expose their capabil
 
 ---
 
-## Try it Now
+## Installation
 
-Add the example bundle and start using MCP servers in two commands:
+### Recommended: Always-Available MCP Support
+
+Add MCP capabilities to **all** your Amplifier sessions with a single command:
+
+```bash
+amplifier bundle add git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml --app
+```
+
+The `--app` flag registers MCP as an "app bundle" that automatically composes with every session, regardless of which primary bundle you use. Configure your servers in `~/.amplifier/mcp.json` and they'll be available everywhere.
+
+### Quick Demo with Example Servers
+
+Try MCP immediately with pre-configured servers (repomix, context7, deepwiki):
 
 ```bash
 amplifier bundle add git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=examples/bundle.md
 amplifier bundle use mcp-example
 ```
 
-This gives you access to [repomix](https://github.com/yamadashy/repomix), [context7](https://github.com/upstash/context7), and [deepwiki](https://deepwiki.com/) MCP servers immediately.
+This example bundle includes foundation and comes with repomix, context7, and deepwiki servers pre-configured.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,21 @@
 # MCP Module Examples
 
-This directory contains a working example showing how to use the MCP tool module with inline server configuration.
+This directory contains example bundles showing how to use the MCP tool module.
 
-## Quick Start
+## Recommended: Always-Available MCP (via Behavior)
+
+For most users, add the MCP behavior with `--app` to make it available across all sessions:
+
+```bash
+# Add MCP behavior as app bundle (always active)
+amplifier bundle add git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml --app
+
+# Configure servers in ~/.amplifier/mcp.json
+```
+
+## Example Bundle with Pre-Configured Servers
+
+This example includes foundation and comes with repomix, context7, and deepwiki servers pre-configured:
 
 ```bash
 amplifier bundle add git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=examples/bundle.md


### PR DESCRIPTION
## Summary

Documents the `--app` flag for adding the MCP behavior as an app bundle, providing users with a cleaner integration path.

## Changes

- Points users to `behaviors/mcp.yaml` as the composable unit (following the same pattern as amplifier-bundle-recipes)
- Keeps example bundle for users who want a complete standalone experience with pre-configured servers
- Recommends `--app` flag approach for always-available MCP functionality

## Rationale

This aligns with Amplifier's bundle/behavior composition philosophy, where behaviors are the fundamental building blocks that can be composed into different bundles based on user needs.