### PR TITLE
fix: populate output field in all error ToolResults for AI visibility

### DIFF
--- a/amplifier_module_tool_mcp/prompt_wrapper.py
+++ b/amplifier_module_tool_mcp/prompt_wrapper.py
@@ -47,7 +47,9 @@ class MCPPromptWrapper:
         # Extract prompt info
         self.prompt_name = prompt_def["name"]
         self._name = f"mcp_{server_name}_prompt_{self.prompt_name}"
-        self._description = prompt_def.get("description", f"Get prompt: {self.prompt_name}")
+        self._description = prompt_def.get(
+            "description", f"Get prompt: {self.prompt_name}"
+        )
         self.prompt_arguments = prompt_def.get("arguments", [])
 
     @property
@@ -121,10 +123,12 @@ class MCPPromptWrapper:
 
         except Exception as e:
             logger.error(f"MCP prompt '{self.name}' retrieval failed: {e}")
+            error_msg = str(e)
             return ToolResult(
                 success=False,
+                output=error_msg,
                 error={
-                    "message": str(e),
+                    "message": error_msg,
                     "mcp_server": self.server_name,
                     "mcp_prompt": self.prompt_name,
                 },
@@ -169,7 +173,9 @@ class MCPPromptWrapper:
 
         # Apply size limit with truncation if needed
         context_info = f"MCP prompt '{self.name}'"
-        messages, was_truncated = truncate_content_if_needed(raw_messages, self.max_content_size, context_info)
+        messages, was_truncated = truncate_content_if_needed(
+            raw_messages, self.max_content_size, context_info
+        )
 
         return messages, was_truncated
 

--- a/amplifier_module_tool_mcp/resource_wrapper.py
+++ b/amplifier_module_tool_mcp/resource_wrapper.py
@@ -49,7 +49,9 @@ class MCPResourceWrapper:
         self.resource_uri = resource_def["uri"]
         resource_name_clean = resource_def["name"].replace("/", "_").replace(":", "_")
         self._name = f"mcp_{server_name}_resource_{resource_name_clean}"
-        self._description = resource_def.get("description", f"Read resource: {resource_def['name']}")
+        self._description = resource_def.get(
+            "description", f"Read resource: {resource_def['name']}"
+        )
         self.mime_type = resource_def.get("mime_type")
 
     @property
@@ -122,10 +124,12 @@ class MCPResourceWrapper:
 
         except Exception as e:
             logger.error(f"MCP resource '{self.name}' read failed: {e}")
+            error_msg = str(e)
             return ToolResult(
                 success=False,
+                output=error_msg,
                 error={
-                    "message": str(e),
+                    "message": error_msg,
                     "mcp_server": self.server_name,
                     "mcp_resource": self.resource_uri,
                 },
@@ -151,7 +155,9 @@ class MCPResourceWrapper:
 
         # Apply size limit with truncation if needed
         context_info = f"MCP resource '{self.name}'"
-        content, was_truncated = truncate_content_if_needed(raw_content, self.max_content_size, context_info)
+        content, was_truncated = truncate_content_if_needed(
+            raw_content, self.max_content_size, context_info
+        )
 
         return content, was_truncated
 

--- a/amplifier_module_tool_mcp/wrapper.py
+++ b/amplifier_module_tool_mcp/wrapper.py
@@ -105,10 +105,12 @@ class MCPToolWrapper:
 
         except Exception as e:
             logger.error(f"MCP tool '{self.name}' failed: {e}")
+            error_msg = str(e)
             return ToolResult(
                 success=False,
+                output=error_msg,
                 error={
-                    "message": str(e),
+                    "message": error_msg,
                     "mcp_server": self.server_name,
                     "mcp_tool": self.tool_name,
                 },
@@ -134,7 +136,9 @@ class MCPToolWrapper:
 
         # Apply size limit with truncation if needed
         context_info = f"MCP tool '{self.name}'"
-        content, was_truncated = truncate_content_if_needed(raw_content, self.max_content_size, context_info)
+        content, was_truncated = truncate_content_if_needed(
+            raw_content, self.max_content_size, context_info
+        )
 
         return content, was_truncated
 


### PR DESCRIPTION
## Summary

- Adds `output=error_msg` alongside `error={"message": error_msg}` for **all 3 error return paths** across `wrapper.py`, `resource_wrapper.py`, and `prompt_wrapper.py`
- `ToolResult.output` is the primary channel the AI reads — when only `error={"message": ...}` was set, error details were invisible to the AI agent

## Context

Same class of bug fixed in amplifier-bundle-lsp [PR #3](https://github.com/microsoft/amplifier-bundle-lsp/pull/3). These MCP wrapper errors are particularly impactful since they wrap ALL MCP tool/resource/prompt execution failures — any error from any MCP server was being swallowed.

## Test plan

- [x] `python_check` clean across all 3 files (ruff format, ruff lint, pyright)
- [x] No logic changes — only adds `output=` parameter to existing returns

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)