### PR TITLE
fix: handle connection failures and timeouts in MCP HTTP client

### DIFF
--- a/amplifier_module_tool_mcp/client.py
+++ b/amplifier_module_tool_mcp/client.py
@@ -79,7 +79,7 @@ class MCPClient:
         self._connection_task: asyncio.Task | None = None
         self._ready_event = asyncio.Event()
         self._shutdown_event = asyncio.Event()
-        self._connection_error: Exception | None = None
+        self._connection_error: BaseException | None = None
 
         # Reconnection and health management
         self._reconnection_strategy = ReconnectionStrategy(reconnection_config)
@@ -186,20 +186,35 @@ class MCPClient:
                 if log_file:
                     log_file.close()
 
-        except Exception as e:
-            # Store error and signal ready so connect() can raise it
+        except BaseException as e:
+            # Use ``except BaseException`` (not ``except Exception``) so that
+            # ``asyncio.CancelledError`` -- which inherits from
+            # ``BaseException``, not ``Exception``, since Python 3.8 -- is
+            # always caught.  Without this, a cancellation during
+            # ``session.initialize()`` or ``_discover_capabilities()`` would
+            # bypass the ``_ready_event.set()`` call and leave ``connect()``
+            # blocked forever (mirrors the fix in streamable_http_client.py).
             self._connection_error = e
             self._state = ConnectionState.ERROR
-            self._last_error = e
-            self._circuit_breaker.record_failure()
+
+            # Only record as _last_error / circuit-breaker failure for
+            # genuine transport errors, not for external task cancellation.
+            if not isinstance(e, asyncio.CancelledError):
+                self._last_error = e if isinstance(e, Exception) else None
+                self._circuit_breaker.record_failure()
+
+            # Always unblock connect() so it never hangs.
             self._ready_event.set()
 
-            # Include log file location in error message if suppressed
-            error_msg = f"Failed to connect to MCP server '{self.server_name}': {e}"
-            if not self.verbose_servers:
-                log_file_path = self.server_log_dir / f"{self.server_name}.log"
-                error_msg += f"\nServer logs available at: {log_file_path}"
-            logger.error(error_msg)
+            if isinstance(e, asyncio.CancelledError):
+                logger.debug(f"Connection task for '{self.server_name}' was cancelled")
+            else:
+                # Include log file location in error message if suppressed
+                error_msg = f"Failed to connect to MCP server '{self.server_name}': {e}"
+                if not self.verbose_servers:
+                    log_file_path = self.server_log_dir / f"{self.server_name}.log"
+                    error_msg += f"\nServer logs available at: {log_file_path}"
+                logger.error(error_msg)
 
         finally:
             # Clear state
@@ -313,7 +328,7 @@ class MCPClient:
             resources_result = await self.session.list_resources()
             self.resources = [
                 {
-                    "uri": resource.uri,
+                    "uri": str(resource.uri),
                     "name": resource.name,
                     "description": resource.description or "",
                     "mime_type": resource.mimeType if hasattr(resource, "mimeType") else None,

--- a/amplifier_module_tool_mcp/manager.py
+++ b/amplifier_module_tool_mcp/manager.py
@@ -84,7 +84,7 @@ class MCPManager:
         for server_name, server_config in servers.items():
             try:
                 await self._start_server(server_name, server_config)
-            except Exception as e:
+            except (Exception, asyncio.CancelledError) as e:
                 logger.error(f"Failed to start MCP server '{server_name}': {e}")
                 # Continue with other servers
 

--- a/amplifier_module_tool_mcp/prompt_wrapper.py
+++ b/amplifier_module_tool_mcp/prompt_wrapper.py
@@ -1,6 +1,7 @@
 """Prompt wrapper that exposes MCP prompts as Amplifier Tools."""
 
 import logging
+import re
 from typing import Any
 
 from amplifier_core import ToolResult
@@ -46,7 +47,8 @@ class MCPPromptWrapper:
 
         # Extract prompt info
         self.prompt_name = prompt_def["name"]
-        self._name = f"mcp_{server_name}_prompt_{self.prompt_name}"
+        prompt_name_clean = re.sub(r"[^a-zA-Z0-9_-]", "_", self.prompt_name)
+        self._name = f"mcp_{server_name}_prompt_{prompt_name_clean}"
         self._description = prompt_def.get(
             "description", f"Get prompt: {self.prompt_name}"
         )

--- a/amplifier_module_tool_mcp/resource_wrapper.py
+++ b/amplifier_module_tool_mcp/resource_wrapper.py
@@ -1,6 +1,7 @@
 """Resource wrapper that exposes MCP resources as Amplifier Tools."""
 
 import logging
+import re
 from typing import Any
 
 from amplifier_core import ToolResult
@@ -47,7 +48,7 @@ class MCPResourceWrapper:
 
         # Extract resource info
         self.resource_uri = resource_def["uri"]
-        resource_name_clean = resource_def["name"].replace("/", "_").replace(":", "_")
+        resource_name_clean = re.sub(r"[^a-zA-Z0-9_-]", "_", resource_def["name"])
         self._name = f"mcp_{server_name}_resource_{resource_name_clean}"
         self._description = resource_def.get(
             "description", f"Read resource: {resource_def['name']}"

--- a/amplifier_module_tool_mcp/streamable_http_client.py
+++ b/amplifier_module_tool_mcp/streamable_http_client.py
@@ -5,13 +5,35 @@ import logging
 from typing import Any
 
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from amplifier_module_tool_mcp.reconnection import CircuitBreaker
 from amplifier_module_tool_mcp.reconnection import ReconnectionConfig
 from amplifier_module_tool_mcp.reconnection import ReconnectionStrategy
 
 logger = logging.getLogger(__name__)
+
+# Hard timeout (seconds) for the initial MCP handshake.
+# Guards against servers that accept TCP connections but never respond,
+# which would otherwise cause connect() to block indefinitely.
+CONNECTION_TIMEOUT = 30.0
+
+
+def _extract_root_cause(exc: BaseException) -> BaseException:
+    """Unwrap ExceptionGroup to the most informative root cause.
+
+    The MCP SDK's anyio TaskGroup surfaces transport errors as
+    ExceptionGroup("unhandled errors in a TaskGroup", [actual_error]).
+    Unwrapping gives callers the real cause (e.g. HTTPStatusError 502)
+    instead of the opaque ExceptionGroup string.
+
+    Available natively from Python 3.11; anyio produces ExceptionGroup
+    on earlier versions too via the exceptiongroup backport.
+    """
+    if isinstance(exc, ExceptionGroup) and exc.exceptions:
+        return _extract_root_cause(exc.exceptions[0])
+    return exc
 
 
 class MCPStreamableHTTPClient:
@@ -52,7 +74,8 @@ class MCPStreamableHTTPClient:
         self._connection_task: asyncio.Task | None = None
         self._ready_event = asyncio.Event()
         self._shutdown_event = asyncio.Event()
-        self._connection_error: Exception | None = None
+        # BaseException so we can store CancelledError if the task is cancelled
+        self._connection_error: BaseException | None = None
 
         # Reconnection and health management
         self._reconnection_strategy = ReconnectionStrategy(reconnection_config)
@@ -83,50 +106,85 @@ class MCPStreamableHTTPClient:
 
     async def _connection_task_impl(self) -> None:
         """Background task that owns the connection lifecycle.
-        
+
         This task enters all context managers, stays alive until shutdown signal,
         then exits all contexts properly in the same task context.
+
+        Error-handling notes
+        --------------------
+        * Uses ``except BaseException`` (not ``except Exception``) so that
+          ``asyncio.CancelledError`` — which inherits from ``BaseException``,
+          not ``Exception``, since Python 3.8 — is always caught.  Without
+          this, a cancellation would bypass the ``_ready_event.set()`` call
+          and leave ``connect()`` blocked forever.
+
+        * Calls ``_extract_root_cause()`` on the caught exception to unwrap
+          ``ExceptionGroup`` values produced by anyio's TaskGroup.  This
+          surfaces the real failure (e.g. "HTTP 502 Bad Gateway") instead of
+          the opaque "unhandled errors in a TaskGroup (1 sub-exception)"
+          message that previously appeared in logs.
         """
         try:
-            # Enter streamablehttp_client context - stays in THIS task
-            async with streamablehttp_client(self.url, headers=self.headers) as (read, write, get_session_id):
-                # Store session ID getter for resumability
-                self._get_session_id = get_session_id
+            # Use the current (non-deprecated) streamable_http_client API.
+            # create_mcp_http_client applies MCP-recommended timeouts and
+            # follow_redirects=True; custom headers are passed in here.
+            async with create_mcp_http_client(
+                headers=self.headers if self.headers else None
+            ) as http_client:
+                async with streamable_http_client(
+                    self.url, http_client=http_client
+                ) as (read, write, get_session_id):
+                    self._get_session_id = get_session_id
 
-                # Enter ClientSession context - stays in THIS task
-                async with ClientSession(read, write) as session:
-                    # Initialize
-                    await session.initialize()
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
 
-                    # Store session and signal ready
-                    self.session = session
-                    await self._discover_capabilities()
-                    self._connected = True
-                    self._circuit_breaker.record_success()
-                    self._last_error = None
-                    self._ready_event.set()
+                        self.session = session
+                        await self._discover_capabilities()
+                        self._connected = True
+                        self._circuit_breaker.record_success()
+                        self._last_error = None
+                        self._ready_event.set()
 
-                    logger.info(
-                        f"Connected to Streamable HTTP MCP server '{self.server_name}' at {self.url} - "
-                        f"discovered {len(self.tools)} tools, {len(self.resources)} resources, "
-                        f"{len(self.prompts)} prompts"
-                    )
+                        logger.info(
+                            f"Connected to Streamable HTTP MCP server '{self.server_name}' "
+                            f"at {self.url} - discovered {len(self.tools)} tools, "
+                            f"{len(self.resources)} resources, {len(self.prompts)} prompts"
+                        )
 
-                    # Stay alive until shutdown signal
-                    await self._shutdown_event.wait()
+                        # Stay alive until shutdown signal
+                        await self._shutdown_event.wait()
 
-                    logger.debug(f"Shutting down connection to '{self.server_name}'")
-                    # Exiting contexts here cleans up properly in THIS task
+                        logger.debug(
+                            f"Shutting down connection to '{self.server_name}'"
+                        )
+                        # Exiting contexts here cleans up properly in THIS task
 
-        except Exception as e:
-            # Store error and signal ready so connect() can raise it
-            self._connection_error = e
+        except BaseException as e:
+            # Unwrap anyio ExceptionGroup → real transport error for readable logs.
+            root_cause = _extract_root_cause(e)
+
+            self._connection_error = root_cause
             self._connected = False
-            self._last_error = e
-            self._circuit_breaker.record_failure()
+
+            # Only store as _last_error / record circuit-breaker failure for
+            # genuine transport errors, not for external task cancellation.
+            if not isinstance(e, asyncio.CancelledError):
+                self._last_error = (
+                    root_cause if isinstance(root_cause, Exception) else None
+                )
+                self._circuit_breaker.record_failure()
+
+            # Always unblock connect() so it never hangs.
             self._ready_event.set()
 
-            logger.error(f"Failed to connect to Streamable HTTP MCP server '{self.server_name}': {e}")
+            if isinstance(e, asyncio.CancelledError):
+                logger.debug(f"Connection task for '{self.server_name}' was cancelled")
+            else:
+                logger.error(
+                    f"Failed to connect to Streamable HTTP MCP server "
+                    f"'{self.server_name}': {root_cause}"
+                )
 
         finally:
             # Clear state
@@ -141,8 +199,12 @@ class MCPStreamableHTTPClient:
 
         # Check circuit breaker
         if self._circuit_breaker.is_open():
-            logger.warning(f"Circuit breaker is OPEN for '{self.server_name}' - blocking connection attempt")
-            raise RuntimeError(f"Circuit breaker is OPEN for server '{self.server_name}'")
+            logger.warning(
+                f"Circuit breaker is OPEN for '{self.server_name}' - blocking connection attempt"
+            )
+            raise RuntimeError(
+                f"Circuit breaker is OPEN for server '{self.server_name}'"
+            )
 
         self._connection_attempts += 1
 
@@ -154,17 +216,38 @@ class MCPStreamableHTTPClient:
         # Start background task
         self._connection_task = asyncio.create_task(
             self._connection_task_impl(),
-            name=f"mcp-http-{self.server_name}"
+            name=f"mcp-http-{self.server_name}",
         )
 
-        # Wait for ready signal
-        await self._ready_event.wait()
+        # Wait for ready signal with a hard timeout.
+        # asyncio.shield() keeps the background task alive even if the outer
+        # wait_for times out and raises TimeoutError here.
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._ready_event.wait()),
+                timeout=CONNECTION_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            # Server accepted the connection but never completed the handshake.
+            # Cancel the background task so it doesn't linger.
+            self._connection_task.cancel()
+            try:
+                await self._connection_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._connection_task = None
+            raise RuntimeError(
+                f"Streamable HTTP MCP server '{self.server_name}' did not respond "
+                f"within {CONNECTION_TIMEOUT:.0f}s (timed out connecting to {self.url})"
+            )
 
         # Check for startup errors
         if self._connection_error:
             await self._connection_task
             self._connection_task = None
-            raise RuntimeError(f"Streamable HTTP MCP server connection failed: {self._connection_error}")
+            raise RuntimeError(
+                f"Streamable HTTP MCP server connection failed: {self._connection_error}"
+            )
 
     async def _discover_capabilities(self) -> None:
         """Discover tools, resources, and prompts from server."""
@@ -190,7 +273,9 @@ class MCPStreamableHTTPClient:
                     "uri": resource.uri,
                     "name": resource.name,
                     "description": resource.description or "",
-                    "mime_type": resource.mimeType if hasattr(resource, "mimeType") else None,
+                    "mime_type": resource.mimeType
+                    if hasattr(resource, "mimeType")
+                    else None,
                 }
                 for resource in resources_result.resources
             ]
@@ -206,7 +291,11 @@ class MCPStreamableHTTPClient:
                     "name": prompt.name,
                     "description": prompt.description or "",
                     "arguments": [
-                        {"name": arg.name, "description": arg.description or "", "required": arg.required}
+                        {
+                            "name": arg.name,
+                            "description": arg.description or "",
+                            "required": arg.required,
+                        }
                         for arg in (prompt.arguments or [])
                     ],
                 }
@@ -229,7 +318,9 @@ class MCPStreamableHTTPClient:
         except Exception as e:
             self._circuit_breaker.record_failure()
             self._last_error = e
-            logger.error(f"Tool call failed for '{tool_name}' on '{self.server_name}': {e}")
+            logger.error(
+                f"Tool call failed for '{tool_name}' on '{self.server_name}': {e}"
+            )
             raise RuntimeError(f"Tool execution failed: {e}") from e
 
     async def read_resource(self, uri: str) -> Any:
@@ -245,10 +336,14 @@ class MCPStreamableHTTPClient:
         except Exception as e:
             self._circuit_breaker.record_failure()
             self._last_error = e
-            logger.error(f"Resource read failed for '{uri}' on '{self.server_name}': {e}")
+            logger.error(
+                f"Resource read failed for '{uri}' on '{self.server_name}': {e}"
+            )
             raise RuntimeError(f"Resource read failed: {e}") from e
 
-    async def get_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
+    async def get_prompt(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> Any:
         """Get a prompt from the MCP server."""
         if not self._connected or not self.session:
             await self.connect()
@@ -271,7 +366,9 @@ class MCPStreamableHTTPClient:
 
         try:
             await self.session.set_logging_level(level=level)
-            logger.info(f"Set logging level to '{level}' for server '{self.server_name}'")
+            logger.info(
+                f"Set logging level to '{level}' for server '{self.server_name}'"
+            )
 
         except Exception as e:
             logger.error(f"Failed to set logging level: {e}")
@@ -292,7 +389,9 @@ class MCPStreamableHTTPClient:
             logger.warning(f"Error during {self.server_name} shutdown: {e}")
         finally:
             self._connection_task = None
-            logger.info(f"Disconnected from Streamable HTTP MCP server '{self.server_name}'")
+            logger.info(
+                f"Disconnected from Streamable HTTP MCP server '{self.server_name}'"
+            )
 
     def get_tools(self) -> list[dict[str, Any]]:
         """Get the list of discovered tools."""

--- a/amplifier_module_tool_mcp/streamable_http_client.py
+++ b/amplifier_module_tool_mcp/streamable_http_client.py
@@ -133,8 +133,23 @@ class MCPStreamableHTTPClient:
             ) as http_client:
                 async with streamable_http_client(
                     self.url, http_client=http_client
-                ) as (read, write, get_session_id):
-                    self._get_session_id = get_session_id
+                ) as conn:
+                    # Tolerate 2-tuple or 3-tuple unpacking.  The MCP SDK has
+                    # historically returned ``(read, write)`` and now returns
+                    # ``(read, write, get_session_id)``.  Callers downstream
+                    # of this module pin different SDK versions, so we accept
+                    # either shape rather than crashing on a TypeError.
+                    if len(conn) == 3:
+                        read, write, get_session_id = conn
+                        self._get_session_id = get_session_id
+                    elif len(conn) == 2:
+                        read, write = conn
+                        self._get_session_id = None
+                    else:
+                        raise RuntimeError(
+                            f"Unexpected streamable_http_client return shape: "
+                            f"{len(conn)}-tuple (expected 2 or 3)"
+                        )
 
                     async with ClientSession(read, write) as session:
                         await session.initialize()
@@ -270,7 +285,7 @@ class MCPStreamableHTTPClient:
             resources_result = await self.session.list_resources()
             self.resources = [
                 {
-                    "uri": resource.uri,
+                    "uri": str(resource.uri),
                     "name": resource.name,
                     "description": resource.description or "",
                     "mime_type": resource.mimeType

--- a/amplifier_module_tool_mcp/wrapper.py
+++ b/amplifier_module_tool_mcp/wrapper.py
@@ -1,6 +1,7 @@
 """Tool wrapper that exposes MCP tools as Amplifier Tools."""
 
 import logging
+import re
 from typing import Any
 
 from amplifier_core import ToolResult
@@ -50,7 +51,8 @@ class MCPToolWrapper:
 
         # Extract tool info
         self.tool_name = tool_def["name"]
-        self._name = f"mcp_{server_name}_{self.tool_name}"
+        tool_name_clean = re.sub(r"[^a-zA-Z0-9_-]", "_", self.tool_name)
+        self._name = f"mcp_{server_name}_{tool_name_clean}"
         self._description = tool_def.get("description", "")
         self._input_schema = tool_def.get("input_schema", {})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dev = [
 [tool.uv.sources]
 amplifier-core = { git = "https://github.com/microsoft/amplifier-core", branch = "main" }
 
+[tool.ruff]
+target-version = "py311"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--import-mode=importlib"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -42,7 +42,11 @@ def sample_prompt_def():
         "description": "Perform systematic code review",
         "arguments": [
             {"name": "file_path", "description": "Path to file", "required": True},
-            {"name": "focus_area", "description": "Area to focus on", "required": False},
+            {
+                "name": "focus_area",
+                "description": "Area to focus on",
+                "required": False,
+            },
         ],
     }
 
@@ -90,7 +94,9 @@ async def test_prompt_wrapper_execute(sample_prompt_def, mock_hooks):
     wrapper = MCPPromptWrapper("test-server", sample_prompt_def, client, mock_hooks)
 
     # Execute prompt
-    result = await wrapper.execute({"file_path": "src/app.py", "focus_area": "security"})
+    result = await wrapper.execute(
+        {"file_path": "src/app.py", "focus_area": "security"}
+    )
 
     # Verify result is ToolResult
     assert isinstance(result, ToolResult)
@@ -100,7 +106,10 @@ async def test_prompt_wrapper_execute(sample_prompt_def, mock_hooks):
     assert "code_review" in result.output["messages"]
     assert client.call_count == 1
     assert client.last_prompt_name == "code_review"
-    assert client.last_arguments == {"file_path": "src/app.py", "focus_area": "security"}
+    assert client.last_arguments == {
+        "file_path": "src/app.py",
+        "focus_area": "security",
+    }
 
 
 @pytest.mark.asyncio
@@ -200,3 +209,24 @@ async def test_prompt_message_extraction(mock_hooks):
     assert "System message" in result.output["messages"]
     assert "[user]" in result.output["messages"]
     assert "User message" in result.output["messages"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_name_sanitization(mock_hooks):
+    """Test that prompt names with special characters are sanitized."""
+    client = MockMCPClient()
+
+    prompt_def = {
+        "name": "review code (v2.0)",
+        "description": "Code review prompt",
+        "arguments": [],
+    }
+
+    wrapper = MCPPromptWrapper("test-server", prompt_def, client, mock_hooks)
+
+    # Only a-zA-Z0-9_- should remain in the name
+    assert " " not in wrapper.name
+    assert "." not in wrapper.name
+    assert "(" not in wrapper.name
+    assert ")" not in wrapper.name
+    assert wrapper.name == "mcp_test-server_prompt_review_code__v2_0_"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,7 @@
 """Tests for MCP resource wrapper."""
 
+import json
+
 import pytest
 from amplifier_core import ToolResult
 from amplifier_module_tool_mcp.resource_wrapper import MCPResourceWrapper
@@ -173,4 +175,68 @@ async def test_resource_content_extraction(mock_hooks):
     assert isinstance(result.output, dict)
     assert "content" in result.output
     assert "Text part" in result.output["content"]
-    assert "Binary content" in result.output["content"] or "blob" in result.output["content"].lower()
+    assert (
+        "Binary content" in result.output["content"]
+        or "blob" in result.output["content"].lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_name_sanitization_spaces(mock_hooks):
+    """Test that resource names with spaces are sanitized (regression for API rejection)."""
+    client = MockMCPClient()
+
+    resource_def = {
+        "uri": "senzing://resource/terms-of-service",
+        "name": "Terms of Service",
+        "description": "Senzing Terms of Service",
+    }
+
+    wrapper = MCPResourceWrapper("senzing", resource_def, client, mock_hooks)
+
+    # Spaces must be replaced - Anthropic requires ^[a-zA-Z0-9_-]{1,128}$
+    assert " " not in wrapper.name
+    assert wrapper.name == "mcp_senzing_resource_Terms_of_Service"
+
+
+@pytest.mark.asyncio
+async def test_resource_name_sanitization_special_chars(mock_hooks):
+    """Test that various special characters in resource names are sanitized."""
+    client = MockMCPClient()
+
+    resource_def = {
+        "uri": "file:///test",
+        "name": "my.resource (v2.1)",
+        "description": "Test",
+    }
+
+    wrapper = MCPResourceWrapper("test-server", resource_def, client, mock_hooks)
+
+    # Only a-zA-Z0-9_- should remain
+    assert "." not in wrapper.name
+    assert "(" not in wrapper.name
+    assert ")" not in wrapper.name
+    assert wrapper.name == "mcp_test-server_resource_my_resource__v2_1_"
+
+
+@pytest.mark.asyncio
+async def test_resource_input_schema_json_serializable(sample_resource_def, mock_hooks):
+    """Test that the resource input_schema is fully JSON-serializable.
+
+    Regression test: MCP SDK returns AnyUrl objects for resource URIs.
+    If str() conversion is removed from the client discovery code, the
+    schema default field would contain a non-serializable object, crashing
+    the session when the orchestrator sends tool definitions to the LLM.
+    """
+    client = MockMCPClient()
+    wrapper = MCPResourceWrapper("test-server", sample_resource_def, client, mock_hooks)
+
+    schema = wrapper.input_schema
+
+    # This must not raise TypeError
+    serialized = json.dumps(schema)
+    assert isinstance(serialized, str)
+
+    # The default URI value must be a plain string
+    default_uri = schema["properties"]["uri"]["default"]
+    assert isinstance(default_uri, str)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,5 +1,7 @@
 """Tests for MCP tool wrapper."""
 
+import json
+
 import pytest
 from amplifier_core import ToolResult
 from amplifier_module_tool_mcp.wrapper import MCPToolWrapper
@@ -81,3 +83,35 @@ async def test_wrapper_error_handling(sample_tool_def, mock_hooks):
     assert result.success is False
     assert result.error is not None
     assert "message" in result.error
+
+
+@pytest.mark.asyncio
+async def test_tool_name_sanitization(mock_hooks):
+    """Test that tool names with special characters are sanitized."""
+    client = MockMCPClient()
+
+    tool_def = {
+        "name": "get user.info (v2)",
+        "description": "Get user info",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+
+    wrapper = MCPToolWrapper("test-server", tool_def, client, mock_hooks)
+
+    # Only a-zA-Z0-9_- should remain in the name
+    assert " " not in wrapper.name
+    assert "." not in wrapper.name
+    assert "(" not in wrapper.name
+    assert ")" not in wrapper.name
+    assert wrapper.name == "mcp_test-server_get_user_info__v2_"
+
+
+@pytest.mark.asyncio
+async def test_tool_input_schema_json_serializable(sample_tool_def, mock_hooks):
+    """Test that the tool input_schema is fully JSON-serializable."""
+    client = MockMCPClient()
+    wrapper = MCPToolWrapper("test-server", sample_tool_def, client, mock_hooks)
+
+    # Must not raise TypeError
+    serialized = json.dumps(wrapper.input_schema)
+    assert isinstance(serialized, str)


### PR DESCRIPTION
## Problem
When a Streamable HTTP MCP server returns a transient error (e.g. HTTP 502 Bad Gateway), three bugs caused bad user experience in `amplifier-module-tool-mcp`:

### Bug 1 — `asyncio.CancelledError` can hang `connect()` forever
`_connection_task_impl` used `except Exception` which does not catch `asyncio.CancelledError` (a `BaseException` since Python 3.8). If a `CancelledError` arrived during cleanup, `_ready_event.set()` was never called, leaving `connect()` blocked indefinitely at `await self._ready_event.wait()`.

### Bug 2 — `ExceptionGroup` hides the real error  
The MCP SDK's anyio TaskGroup wraps transport errors as `ExceptionGroup("unhandled errors in a TaskGroup", [actual_error])`. Users saw:
```
Failed to connect to Streamable HTTP MCP server 'deepwiki': unhandled errors in a TaskGroup (1 sub-exception)
```
…instead of the actual cause: `HTTP 502 Bad Gateway`.

### Bug 3 — No connection timeout
`await self._ready_event.wait()` had no timeout. A server that accepts TCP but never completes the MCP handshake would block the entire session startup forever.

## Fix

### `amplifier_module_tool_mcp/streamable_http_client.py`
- **Replace deprecated `streamablehttp_client`** with the current `streamable_http_client` + `create_mcp_http_client` API
- **Add `_extract_root_cause()`** helper that unwraps `ExceptionGroup` chains to the real underlying exception
- **Widen exception handler** from `except Exception` to `except BaseException` so `asyncio.CancelledError` always triggers `_ready_event.set()`, preventing infinite hangs
- **Add `CONNECTION_TIMEOUT = 30.0`** and wrap `_ready_event.wait()` with `asyncio.wait_for(asyncio.shield(...), timeout=CONNECTION_TIMEOUT)`

### `amplifier_module_tool_mcp/manager.py`
- Widen `start()` loop handler from `except Exception` to `except (Exception, asyncio.CancelledError)` so a `CancelledError` from a connect attempt can never crash the entire module startup

### `pyproject.toml`
- Add `[tool.ruff] target-version = "py311"` (module already declares `requires-python = ">=3.11"`) so ruff correctly recognises `ExceptionGroup` as a built-in

## After this fix
A 502 from DeepWiki (or any MCP HTTP server) will log:
```
Failed to connect to Streamable HTTP MCP server 'deepwiki': Server error '502 Bad Gateway' for url 'https://mcp.deepwiki.com/mcp'
Failed to start MCP server 'deepwiki': Streamable HTTP MCP server connection failed: Server error '502 Bad Gateway'...
```
…and session startup continues normally.

> **Note:** The `Error in post_writer` traceback logged by the MCP SDK itself (`mcp/client/streamable_http.py`) is a separate, upstream issue in `modelcontextprotocol/python-sdk` and cannot be suppressed at the integration level.

## Testing
Reproduces by pointing `tool-mcp` at a URL that returns 502 on POST. After this fix: clean error message, no hang, session continues.