### PR TITLE
fix: support mcp SDK 2.x field rename (inputSchema -> input_schema)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module enables Amplifier to connect to MCP servers and expose their capabil
 
 **Production Proven:** 60 capabilities from 5 MCP servers (41 tools + 19 prompts)
 
-**Status:** ✅ Production Ready | **Version:** 0.2.2 | **Tests:** 52/52 passing
+**Status:** ✅ Production Ready | **Version:** 0.2.3 | **Tests:** 71/71 passing
 
 ---
 

--- a/amplifier_module_tool_mcp/__init__.py
+++ b/amplifier_module_tool_mcp/__init__.py
@@ -16,7 +16,7 @@ from amplifier_core import ModuleCoordinator
 
 from amplifier_module_tool_mcp.manager import MCPManager
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __all__ = ["mount", "MCPManager"]
 
 logger = logging.getLogger(__name__)

--- a/amplifier_module_tool_mcp/client.py
+++ b/amplifier_module_tool_mcp/client.py
@@ -10,9 +10,12 @@ from mcp import ClientSession
 from mcp import StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+from amplifier_module_tool_mcp.errors import extract_root_cause
 from amplifier_module_tool_mcp.reconnection import CircuitBreaker
 from amplifier_module_tool_mcp.reconnection import ReconnectionConfig
 from amplifier_module_tool_mcp.reconnection import ReconnectionStrategy
+from amplifier_module_tool_mcp.sdk_compat import get_input_schema
+from amplifier_module_tool_mcp.sdk_compat import get_mime_type
 
 logger = logging.getLogger(__name__)
 
@@ -194,13 +197,19 @@ class MCPClient:
             # ``session.initialize()`` or ``_discover_capabilities()`` would
             # bypass the ``_ready_event.set()`` call and leave ``connect()``
             # blocked forever (mirrors the fix in streamable_http_client.py).
-            self._connection_error = e
+            # Unwrap anyio ExceptionGroup -> real error for readable logs.
+            # Without this, ``str()`` on the group yields only "unhandled
+            # errors in a TaskGroup (1 sub-exception)" and the actual failure
+            # is invisible (mirrors streamable_http_client.py).
+            root_cause = extract_root_cause(e)
+
+            self._connection_error = root_cause
             self._state = ConnectionState.ERROR
 
             # Only record as _last_error / circuit-breaker failure for
             # genuine transport errors, not for external task cancellation.
             if not isinstance(e, asyncio.CancelledError):
-                self._last_error = e if isinstance(e, Exception) else None
+                self._last_error = root_cause if isinstance(root_cause, Exception) else None
                 self._circuit_breaker.record_failure()
 
             # Always unblock connect() so it never hangs.
@@ -210,7 +219,9 @@ class MCPClient:
                 logger.debug(f"Connection task for '{self.server_name}' was cancelled")
             else:
                 # Include log file location in error message if suppressed
-                error_msg = f"Failed to connect to MCP server '{self.server_name}': {e}"
+                error_msg = (
+                    f"Failed to connect to MCP server '{self.server_name}': {root_cause}"
+                )
                 if not self.verbose_servers:
                     log_file_path = self.server_log_dir / f"{self.server_name}.log"
                     error_msg += f"\nServer logs available at: {log_file_path}"
@@ -318,7 +329,7 @@ class MCPClient:
             {
                 "name": tool.name,
                 "description": tool.description or "",
-                "input_schema": tool.inputSchema,
+                "input_schema": get_input_schema(tool),
             }
             for tool in tools_result.tools
         ]
@@ -331,7 +342,7 @@ class MCPClient:
                     "uri": str(resource.uri),
                     "name": resource.name,
                     "description": resource.description or "",
-                    "mime_type": resource.mimeType if hasattr(resource, "mimeType") else None,
+                    "mime_type": get_mime_type(resource),
                 }
                 for resource in resources_result.resources
             ]

--- a/amplifier_module_tool_mcp/errors.py
+++ b/amplifier_module_tool_mcp/errors.py
@@ -1,0 +1,20 @@
+"""Error-shape helpers shared by the MCP transports."""
+
+__all__ = ["extract_root_cause"]
+
+
+def extract_root_cause(exc: BaseException) -> BaseException:
+    """Unwrap ExceptionGroup to the most informative root cause.
+
+    The MCP SDK's anyio TaskGroup surfaces errors as
+    ExceptionGroup("unhandled errors in a TaskGroup", [actual_error]).
+    ``str()`` on that group omits the sub-exceptions entirely, so logging it
+    directly hides the real failure. Unwrapping gives callers the actual cause
+    (e.g. an HTTP 502, or an AttributeError from an SDK field rename).
+
+    Available natively from Python 3.11; anyio produces ExceptionGroup on
+    earlier versions too via the exceptiongroup backport.
+    """
+    if isinstance(exc, ExceptionGroup) and exc.exceptions:
+        return extract_root_cause(exc.exceptions[0])
+    return exc

--- a/amplifier_module_tool_mcp/sdk_compat.py
+++ b/amplifier_module_tool_mcp/sdk_compat.py
@@ -1,0 +1,77 @@
+"""Compatibility helpers for reading MCP SDK models across SDK major versions.
+
+The MCP Python SDK renamed its ``mcp.types`` model fields from camelCase to
+snake_case in 2.0.0. The JSON wire names are unchanged (they became pydantic
+aliases), but *Python attribute access* differs between the two majors:
+
+===================  ===================  ===================
+Wire field           ``mcp`` 1.x          ``mcp`` >= 2.0
+===================  ===================  ===================
+``inputSchema``      ``.inputSchema``     ``.input_schema``
+``mimeType``         ``.mimeType``        ``.mime_type``
+===================  ===================  ===================
+
+Reading a single hard-coded attribute name therefore breaks on one major or the
+other. ``mcp`` 2.0.0 was published 2026-07-28; because this module declares an
+unbounded ``mcp>=1.0.0`` dependency, existing installs picked it up on their
+next resolve and every MCP server failed to connect with
+``'Tool' object has no attribute 'inputSchema'``.
+
+The helpers below read whichever attribute the installed SDK exposes, so the
+module works unchanged on both majors.
+"""
+
+from typing import Any
+
+__all__ = ["get_input_schema", "get_mime_type"]
+
+
+def get_input_schema(tool: Any) -> dict[str, Any]:
+    """Return an MCP tool's JSON input schema.
+
+    Args:
+        tool: An ``mcp.types.Tool`` (or any object exposing the schema under
+            either the 1.x or 2.x attribute name).
+
+    Returns:
+        The tool's JSON Schema object.
+
+    Raises:
+        AttributeError: If neither attribute name is present. ``inputSchema`` is
+            required by the MCP specification, so its absence means the SDK
+            changed incompatibly again. Failing loudly beats silently
+            registering a tool with no parameter schema, which would make the
+            model call it incorrectly. Both transports unwrap anyio's
+            ExceptionGroup (see ``errors.extract_root_cause``), so this message
+            reaches the log rather than being masked.
+    """
+    for attr in ("input_schema", "inputSchema"):
+        schema = getattr(tool, attr, None)
+        if schema is not None:
+            return schema
+
+    raise AttributeError(
+        f"{type(tool).__name__} exposes neither 'input_schema' (mcp >= 2.0) nor "
+        "'inputSchema' (mcp 1.x). The installed MCP SDK is incompatible with "
+        "this module; please report it at "
+        "https://github.com/microsoft/amplifier-module-tool-mcp/issues"
+    )
+
+
+def get_mime_type(resource: Any) -> str | None:
+    """Return an MCP resource's MIME type, or ``None`` when it declares none.
+
+    Args:
+        resource: An ``mcp.types.Resource`` (or any object exposing the MIME
+            type under either the 1.x or 2.x attribute name).
+
+    Returns:
+        The declared MIME type, or ``None``. ``mimeType`` is optional in the MCP
+        specification, so absence is a valid outcome rather than an error.
+    """
+    for attr in ("mime_type", "mimeType"):
+        mime_type = getattr(resource, attr, None)
+        if mime_type is not None:
+            return mime_type
+
+    return None

--- a/amplifier_module_tool_mcp/streamable_http_client.py
+++ b/amplifier_module_tool_mcp/streamable_http_client.py
@@ -8,9 +8,12 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared._httpx_utils import create_mcp_http_client
 
+from amplifier_module_tool_mcp.errors import extract_root_cause
 from amplifier_module_tool_mcp.reconnection import CircuitBreaker
 from amplifier_module_tool_mcp.reconnection import ReconnectionConfig
 from amplifier_module_tool_mcp.reconnection import ReconnectionStrategy
+from amplifier_module_tool_mcp.sdk_compat import get_input_schema
+from amplifier_module_tool_mcp.sdk_compat import get_mime_type
 
 logger = logging.getLogger(__name__)
 
@@ -18,22 +21,6 @@ logger = logging.getLogger(__name__)
 # Guards against servers that accept TCP connections but never respond,
 # which would otherwise cause connect() to block indefinitely.
 CONNECTION_TIMEOUT = 30.0
-
-
-def _extract_root_cause(exc: BaseException) -> BaseException:
-    """Unwrap ExceptionGroup to the most informative root cause.
-
-    The MCP SDK's anyio TaskGroup surfaces transport errors as
-    ExceptionGroup("unhandled errors in a TaskGroup", [actual_error]).
-    Unwrapping gives callers the real cause (e.g. HTTPStatusError 502)
-    instead of the opaque ExceptionGroup string.
-
-    Available natively from Python 3.11; anyio produces ExceptionGroup
-    on earlier versions too via the exceptiongroup backport.
-    """
-    if isinstance(exc, ExceptionGroup) and exc.exceptions:
-        return _extract_root_cause(exc.exceptions[0])
-    return exc
 
 
 class MCPStreamableHTTPClient:
@@ -118,7 +105,7 @@ class MCPStreamableHTTPClient:
           this, a cancellation would bypass the ``_ready_event.set()`` call
           and leave ``connect()`` blocked forever.
 
-        * Calls ``_extract_root_cause()`` on the caught exception to unwrap
+        * Calls ``extract_root_cause()`` on the caught exception to unwrap
           ``ExceptionGroup`` values produced by anyio's TaskGroup.  This
           surfaces the real failure (e.g. "HTTP 502 Bad Gateway") instead of
           the opaque "unhandled errors in a TaskGroup (1 sub-exception)"
@@ -177,7 +164,7 @@ class MCPStreamableHTTPClient:
 
         except BaseException as e:
             # Unwrap anyio ExceptionGroup → real transport error for readable logs.
-            root_cause = _extract_root_cause(e)
+            root_cause = extract_root_cause(e)
 
             self._connection_error = root_cause
             self._connected = False
@@ -275,7 +262,7 @@ class MCPStreamableHTTPClient:
             {
                 "name": tool.name,
                 "description": tool.description or "",
-                "input_schema": tool.inputSchema,
+                "input_schema": get_input_schema(tool),
             }
             for tool in tools_result.tools
         ]
@@ -288,9 +275,7 @@ class MCPStreamableHTTPClient:
                     "uri": str(resource.uri),
                     "name": resource.name,
                     "description": resource.description or "",
-                    "mime_type": resource.mimeType
-                    if hasattr(resource, "mimeType")
-                    else None,
+                    "mime_type": get_mime_type(resource),
                 }
                 for resource in resources_result.resources
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplifier-module-tool-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "MCP (Model Context Protocol) tool module for Amplifier"
 license = "MIT"
 readme = "README.md"
@@ -9,7 +9,10 @@ authors = [
     { name = "Brian Krabach" },
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    # 1.24.0 is the first release exposing mcp.client.streamable_http
+    # .streamable_http_client, which streamable_http_client.py imports
+    # unconditionally. Anything older fails at import time.
+    "mcp>=1.24.0",
     "pydantic>=2.0",
 ]
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,124 @@
+"""Offline tests for capability discovery across MCP SDK majors.
+
+These cover the actual regression sites -- ``_discover_capabilities()`` in both
+transports -- rather than only the compatibility helpers. The production break
+was a hard-coded ``tool.inputSchema`` here, so a test that never executes these
+methods would not have caught it. Everything is driven by a fake session, so
+these run without an MCP server or network.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from amplifier_module_tool_mcp.client import MCPClient
+from amplifier_module_tool_mcp.streamable_http_client import MCPStreamableHTTPClient
+
+SCHEMA = {"type": "object", "properties": {"q": {"type": "string"}}}
+
+
+def _legacy_tool():
+    """An ``mcp`` 1.x-shaped tool: camelCase attribute."""
+    return SimpleNamespace(name="search", description="Search", inputSchema=SCHEMA)
+
+
+def _modern_tool():
+    """An ``mcp`` >= 2.0-shaped tool: snake_case attribute."""
+    return SimpleNamespace(name="search", description="Search", input_schema=SCHEMA)
+
+
+def _legacy_resource():
+    return SimpleNamespace(
+        uri="file:///notes.md",
+        name="notes",
+        description="Notes",
+        mimeType="text/markdown",
+    )
+
+
+def _modern_resource():
+    return SimpleNamespace(
+        uri="file:///notes.md",
+        name="notes",
+        description="Notes",
+        mime_type="text/markdown",
+    )
+
+
+class FakeSession:
+    """Minimal stand-in for ``mcp.ClientSession`` during discovery."""
+
+    def __init__(self, tool, resource):
+        self._tool = tool
+        self._resource = resource
+
+    async def list_tools(self):
+        return SimpleNamespace(tools=[self._tool])
+
+    async def list_resources(self):
+        return SimpleNamespace(resources=[self._resource])
+
+    async def list_prompts(self):
+        argument = SimpleNamespace(name="topic", description="Topic", required=True)
+        prompt = SimpleNamespace(
+            name="summarize", description="Summarize", arguments=[argument]
+        )
+        return SimpleNamespace(prompts=[prompt])
+
+
+def _clients():
+    """One instance of each transport, neither of which will be connected."""
+    return {
+        "stdio": MCPClient(server_name="fake", command="true", args=[]),
+        "streamable-http": MCPStreamableHTTPClient(
+            server_name="fake", url="http://localhost:1/mcp"
+        ),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["stdio", "streamable-http"])
+@pytest.mark.parametrize(
+    ("sdk_shape", "tool", "resource"),
+    [
+        ("mcp 1.x", _legacy_tool, _legacy_resource),
+        ("mcp >= 2.0", _modern_tool, _modern_resource),
+    ],
+)
+async def test_discovery_reads_renamed_fields(transport, sdk_shape, tool, resource):
+    """Discovery must produce the same output on either SDK major."""
+    client = _clients()[transport]
+    client.session = FakeSession(tool(), resource())
+
+    await client._discover_capabilities()
+
+    assert client.tools == [
+        {"name": "search", "description": "Search", "input_schema": SCHEMA}
+    ], f"{transport} lost the input schema on {sdk_shape}"
+    assert client.resources == [
+        {
+            "uri": "file:///notes.md",
+            "name": "notes",
+            "description": "Notes",
+            "mime_type": "text/markdown",
+        }
+    ], f"{transport} lost the MIME type on {sdk_shape}"
+    assert client.prompts == [
+        {
+            "name": "summarize",
+            "description": "Summarize",
+            "arguments": [{"name": "topic", "description": "Topic", "required": True}],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["stdio", "streamable-http"])
+async def test_discovery_is_a_noop_without_a_session(transport):
+    client = _clients()[transport]
+
+    await client._discover_capabilities()
+
+    assert client.tools == []
+    assert client.resources == []
+    assert client.prompts == []

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -1,0 +1,95 @@
+"""Tests for MCP SDK version-compatibility helpers.
+
+The MCP Python SDK renamed model fields from camelCase to snake_case in 2.0.0.
+These tests pin the behaviour of the accessors against both attribute shapes,
+plus whatever shape the currently-installed SDK actually uses.
+"""
+
+import pytest
+from mcp.types import Resource, Tool
+
+from amplifier_module_tool_mcp.sdk_compat import get_input_schema, get_mime_type
+
+SCHEMA = {"type": "object", "properties": {"q": {"type": "string"}}}
+
+
+class LegacyTool:
+    """Shape exposed by mcp 1.x: camelCase attribute."""
+
+    def __init__(self, input_schema):
+        self.name = "legacy"
+        self.inputSchema = input_schema  # mirrors the mcp 1.x field name
+
+
+class ModernTool:
+    """Shape exposed by mcp >= 2.0: snake_case attribute."""
+
+    def __init__(self, input_schema):
+        self.name = "modern"
+        self.input_schema = input_schema
+
+
+class SchemalessTool:
+    """Shape exposed by no released SDK - neither attribute present."""
+
+    name = "schemaless"
+
+
+def test_get_input_schema_reads_legacy_camel_case_attribute():
+    assert get_input_schema(LegacyTool(SCHEMA)) == SCHEMA
+
+
+def test_get_input_schema_reads_modern_snake_case_attribute():
+    assert get_input_schema(ModernTool(SCHEMA)) == SCHEMA
+
+
+def test_get_input_schema_works_on_installed_sdk_model():
+    """Guards the real regression: mcp 2.0.0 broke ``tool.inputSchema``."""
+    tool = Tool(name="real", inputSchema=SCHEMA)
+    assert get_input_schema(tool) == SCHEMA
+
+
+def test_get_input_schema_raises_actionable_error_when_absent():
+    with pytest.raises(AttributeError) as exc_info:
+        get_input_schema(SchemalessTool())
+
+    message = str(exc_info.value)
+    assert "input_schema" in message
+    assert "inputSchema" in message
+
+
+class LegacyResource:
+    """Shape exposed by mcp 1.x: camelCase attribute."""
+
+    def __init__(self, mime_type):
+        self.mimeType = mime_type  # mirrors the mcp 1.x field name
+
+
+class ModernResource:
+    """Shape exposed by mcp >= 2.0: snake_case attribute."""
+
+    def __init__(self, mime_type):
+        self.mime_type = mime_type
+
+
+def test_get_mime_type_reads_legacy_camel_case_attribute():
+    assert get_mime_type(LegacyResource("text/markdown")) == "text/markdown"
+
+
+def test_get_mime_type_reads_modern_snake_case_attribute():
+    assert get_mime_type(ModernResource("text/markdown")) == "text/markdown"
+
+
+def test_get_mime_type_works_on_installed_sdk_model():
+    resource = Resource(uri="file:///tmp/a.md", name="a", mimeType="text/markdown")
+    assert get_mime_type(resource) == "text/markdown"
+
+
+def test_get_mime_type_returns_none_when_sdk_model_declares_none():
+    """``mimeType`` is optional in the MCP spec, so absence is not an error."""
+    resource = Resource(uri="file:///tmp/a.md", name="a")
+    assert get_mime_type(resource) is None
+
+
+def test_get_mime_type_returns_none_when_neither_attribute_exists():
+    assert get_mime_type(object()) is None


### PR DESCRIPTION
## Problem

`mcp` 2.0.0 was published to PyPI on **2026-07-28**. It renames the `mcp.types` model fields from camelCase to snake_case. The JSON wire names are preserved as pydantic aliases (`MCPModel` sets `alias_generator=to_camel, populate_by_name=True`), so **the protocol is unchanged** — but *Python attribute access* changed:

| Wire field | `mcp` 1.x | `mcp` >= 2.0 |
|---|---|---|
| `inputSchema` | `.inputSchema` | `.input_schema` |
| `mimeType` | `.mimeType` | `.mime_type` |

Because this module declares an unbounded `mcp>=1.0.0`, existing installs picked up 2.0.0 on their next resolve and **every configured MCP server stopped connecting**, on both transports:

```
Failed to connect to MCP server '<stdio-server>': unhandled errors in a TaskGroup (1 sub-exception)
Failed to connect to Streamable HTTP MCP server '<http-server>': 'Tool' object has no attribute 'inputSchema'
```

One root cause, two very different error strings — see change 3 below for why, and why that made this look like a transport problem.

Two call sites were affected, with different failure modes:

- **`Tool.inputSchema`** (`client.py:321`, `streamable_http_client.py:278`) — hard `AttributeError`. Kills capability discovery, so the connection fails for every server.
- **`Resource.mimeType`** (`client.py:334`, `streamable_http_client.py:291`) — **silent** degradation, not a crash. Both sites were already guarded by `hasattr(resource, "mimeType")`, so on 2.x the guard simply falls through and every discovered resource reports `mime_type: None`.

I swept the rest of the module for other 2.x-affected reads and found none: `content_utils.py`, `wrapper.py`, `resource_wrapper.py` and `prompt_wrapper.py` are duck-typed on `text` / `blob` / `contents` / `messages`, and every SDK symbol this module imports (`ClientSession`, `StdioServerParameters`, `stdio_client`, `streamable_http_client`, `create_mcp_http_client`) still exists in 2.0.0 with a compatible signature.

## Changes

**1. Corrects the dependency floor: `mcp>=1.0.0` -> `mcp>=1.24.0`.**

This is a separate latent bug found while auditing the constraint. `streamable_http_client.py:8` unconditionally imports `streamable_http_client` (underscore spelling) and the import chain `__init__.py` -> `manager.py` -> `streamable_http_client.py` is unconditional, so on any `mcp` below 1.24.0 `import amplifier_module_tool_mcp` raises `ImportError` and the module cannot mount at all. Verified by inspecting wheels for 1.0.0 / 1.9.0 / 1.15.0 / 1.20.0 / 1.22.0 / 1.23.0 / 1.24.0 / 1.25.0 / 1.26.0 / 1.29.0 / 2.0.0 — the underscore spelling is absent through 1.23.0 (which only had `streamablehttp_client`) and first appears in 1.24.0. Confirmed by install: on 1.23.0, `ImportError: cannot import name 'streamable_http_client' ... Did you mean: 'streamablehttp_client'?`; on 1.24.0 it imports cleanly.

No upper bound is added, because the shim below makes the module work on 2.x as well.

**2. New `sdk_compat.py` with `get_input_schema()` / `get_mime_type()`.**

Each reads whichever attribute name the installed SDK exposes. Both transports now call these instead of hard-coding a name.

The two differ deliberately on the missing case, following the MCP spec: `inputSchema` is **required**, so `get_input_schema` raises a descriptive `AttributeError` naming both attribute names — failing loudly beats silently registering a tool with no parameter schema, which would make the model call it wrong. `mimeType` is **optional**, so `get_mime_type` returns `None`.

**3. Promotes `_extract_root_cause()` to a shared `errors.py`, and uses it in the stdio transport too.**

`str()` on an anyio `ExceptionGroup` yields only `"unhandled errors in a TaskGroup (1 sub-exception)"` and drops the sub-exception text entirely. `_discover_capabilities()` runs inside `stdio_client`'s TaskGroup, so **any** error raised there — including the `AttributeError` this PR fixes — reached the log and the re-raised `RuntimeError` with the real cause invisible. `streamable_http_client.py` already had a private `_extract_root_cause` for exactly this; it is promoted to `errors.extract_root_cause()` and used by both transports, so their error reporting is now symmetric.

Demonstrated with an exception raised inside stdio discovery:

| | reported message |
|---|---|
| before | `MCP server connection failed: unhandled errors in a TaskGroup (1 sub-exception)` |
| after | `MCP server connection failed: 'Tool' object has no attribute 'inputSchema'` |

That is a meaningful diagnostics improvement independent of this bug, but it is separable — happy to split it out if you'd rather keep the PR to one concern.

**4. New `tests/test_discovery.py` covering the actual regression sites.**

Helper-level tests alone would not have caught this: the break was at `client.py:321` / `streamable_http_client.py:278`, and the only existing coverage of `_discover_capabilities()` is in `test_integration.py` (gated on `shutil.which("npx")`) and `test_http_integration.py` (hits a live endpoint). The new tests drive `_discover_capabilities()` on **both** transports via a fake session, parametrized over both mcp 1.x-shaped and 2.x-shaped tool/resource objects. No server, no network.

## Verification

| Check | Result |
|---|---|
| Full suite, `mcp==1.24.0` (the new floor) | 71 passed |
| Full suite, `mcp==1.29.0` | 71 passed |
| Full suite, `mcp==2.0.0` | 71 passed |
| E2E capability discovery vs a real stdio MCP server, `mcp==2.0.0` | connects; 14 tools, all with valid dict input schemas |
| Same E2E, `mcp==1.29.0` | identical result |
| Same E2E on unpatched `main` + `mcp==2.0.0` | reproduces the reported failure |
| Import on `mcp==1.23.0` (below the new floor) | `ImportError`, as expected — floor is correct |
| `ruff check` | zero new violations vs `main`; all new files clean |

Test venvs used `amplifier-core==1.6.0` from PyPI rather than the git source in `[tool.uv.sources]`, because the git build needs rustc >= 1.92 (unrelated to this change).

## Scope

Version 0.2.2 -> 0.2.3 across `pyproject.toml`, `__version__` in `__init__.py`, and the README status line. No behavior change on `mcp` 1.x other than the improved stdio error message. No changes to reconnection, content protection, or the public module surface beyond the two new helper modules.

## Note on contribution policy

The README says this project isn't currently accepting external contributions. Opening this anyway because it's a live breakage for anyone who resolves dependencies after 2026-07-28 — feel free to cherry-pick the diff and close this if that's easier than merging a fork PR.
